### PR TITLE
tuples, all primitives, refactor

### DIFF
--- a/crates/crabslab/src/impl_slab_item/glam.rs
+++ b/crates/crabslab/src/impl_slab_item/glam.rs
@@ -1,0 +1,181 @@
+
+use crate::SlabItem;
+
+
+impl SlabItem for glam::Mat4 {
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let Self {
+            x_axis,
+            y_axis,
+            z_axis,
+            w_axis,
+        } = self;
+        let index = x_axis.read_slab(index, slab);
+        let index = y_axis.read_slab(index, slab);
+        let index = z_axis.read_slab(index, slab);
+        w_axis.read_slab(index, slab)
+    }
+
+    fn slab_size() -> usize {
+        16
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        let Self {
+            x_axis,
+            y_axis,
+            z_axis,
+            w_axis,
+        } = self;
+        let index = x_axis.write_slab(index, slab);
+        let index = y_axis.write_slab(index, slab);
+        let index = z_axis.write_slab(index, slab);
+        w_axis.write_slab(index, slab)
+    }
+}
+
+impl SlabItem for glam::Vec2 {
+    fn slab_size() -> usize {
+        2
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let index = self.x.read_slab(index, slab);
+        let index = self.y.read_slab(index, slab);
+        index
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        if slab.len() < index + 2 {
+            return index;
+        }
+        let index = self.x.write_slab(index, slab);
+        let index = self.y.write_slab(index, slab);
+        index
+    }
+}
+
+impl SlabItem for glam::Vec3 {
+    fn slab_size() -> usize {
+        3
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let Self { x, y, z } = self;
+        let index = x.read_slab(index, slab);
+        let index = y.read_slab(index, slab);
+        let index = z.read_slab(index, slab);
+        index
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        let Self { x, y, z } = self;
+        let index = x.write_slab(index, slab);
+        let index = y.write_slab(index, slab);
+        let index = z.write_slab(index, slab);
+        index
+    }
+}
+
+impl SlabItem for glam::Vec4 {
+    fn slab_size() -> usize {
+        4
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let index = self.x.read_slab(index, slab);
+        let index = self.y.read_slab(index, slab);
+        let index = self.z.read_slab(index, slab);
+        self.w.read_slab(index, slab)
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        let index = self.x.write_slab(index, slab);
+        let index = self.y.write_slab(index, slab);
+        let index = self.z.write_slab(index, slab);
+        self.w.write_slab(index, slab)
+    }
+}
+
+impl SlabItem for glam::Quat {
+    fn slab_size() -> usize {
+        16
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let index = self.x.read_slab(index, slab);
+        let index = self.y.read_slab(index, slab);
+        let index = self.z.read_slab(index, slab);
+        self.w.read_slab(index, slab)
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        let index = self.x.write_slab(index, slab);
+        let index = self.y.write_slab(index, slab);
+        let index = self.z.write_slab(index, slab);
+        self.w.write_slab(index, slab)
+    }
+}
+
+impl SlabItem for glam::UVec2 {
+    fn slab_size() -> usize {
+        2
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let index = self.x.read_slab(index, slab);
+        let index = self.y.read_slab(index, slab);
+        index
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        let index = self.x.write_slab(index, slab);
+        let index = self.y.write_slab(index, slab);
+        index
+    }
+}
+
+impl SlabItem for glam::UVec3 {
+    fn slab_size() -> usize {
+        3
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let index = self.x.read_slab(index, slab);
+        let index = self.y.read_slab(index, slab);
+        let index = self.z.read_slab(index, slab);
+        index
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        let index = self.x.write_slab(index, slab);
+        let index = self.y.write_slab(index, slab);
+        let index = self.z.write_slab(index, slab);
+        index
+    }
+}
+
+impl SlabItem for glam::UVec4 {
+    fn slab_size() -> usize {
+        4
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let index = self.x.read_slab(index, slab);
+        let index = self.y.read_slab(index, slab);
+        let index = self.z.read_slab(index, slab);
+        let index = self.w.read_slab(index, slab);
+        index
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        if slab.len() < index + 4 {
+            return index;
+        }
+        let index = self.x.write_slab(index, slab);
+        let index = self.y.write_slab(index, slab);
+        let index = self.z.write_slab(index, slab);
+        let index = self.w.write_slab(index, slab);
+        index
+    }
+}

--- a/crates/crabslab/src/impl_slab_item/mod.rs
+++ b/crates/crabslab/src/impl_slab_item/mod.rs
@@ -1,0 +1,80 @@
+
+
+mod primitives;
+mod tuples;
+
+#[cfg(feature = "glam")]
+mod glam;
+
+
+
+
+use crate::SlabItem;
+
+
+impl<T: SlabItem + Default> SlabItem for Option<T> {
+    fn slab_size() -> usize {
+        1 + T::slab_size()
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let mut proxy = 0u32;
+        let index = proxy.read_slab(index, slab);
+        if proxy == 1 {
+            let mut t = T::default();
+            let index = t.read_slab(index, slab);
+            *self = Some(t);
+            index
+        } else {
+            *self = None;
+            index + T::slab_size()
+        }
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        if let Some(t) = self {
+            let index = 1u32.write_slab(index, slab);
+            t.write_slab(index, slab)
+        } else {
+            let index = 0u32.write_slab(index, slab);
+            index + T::slab_size()
+        }
+    }
+}
+
+impl<T: SlabItem, const N: usize> SlabItem for [T; N] {
+    fn slab_size() -> usize {
+        <T as SlabItem>::slab_size() * N
+    }
+
+    fn read_slab(&mut self, mut index: usize, slab: &[u32]) -> usize {
+        for i in 0..N {
+            index = self[i].read_slab(index, slab);
+        }
+        index
+    }
+
+    fn write_slab(&self, mut index: usize, slab: &mut [u32]) -> usize {
+        for i in 0..N {
+            index = self[i].write_slab(index, slab);
+        }
+        index
+    }
+}
+
+
+use core::marker::PhantomData;
+
+impl<T: core::any::Any> SlabItem for PhantomData<T> {
+    fn slab_size() -> usize {
+        0
+    }
+
+    fn read_slab(&mut self, index: usize, _: &[u32]) -> usize {
+        index
+    }
+
+    fn write_slab(&self, index: usize, _: &mut [u32]) -> usize {
+        index
+    }
+}

--- a/crates/crabslab/src/impl_slab_item/primitives.rs
+++ b/crates/crabslab/src/impl_slab_item/primitives.rs
@@ -1,0 +1,142 @@
+
+use crate::SlabItem;
+
+
+
+macro_rules! impl_underflow_primitive {
+    ($type: ty) => {
+        impl SlabItem for $type {
+            fn slab_size() -> usize {
+                1
+            }
+        
+            fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+                if slab.len() > index {
+                    *self = slab[index] as $type;
+                    index + 1
+                } else {
+                    index
+                }
+            }
+        
+            fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+                if slab.len() > index {
+                    slab[index] = *self as u32;
+                    index + 1
+                } else {
+                    index
+                }
+            }
+        }
+    };
+}
+
+
+macro_rules! impl_overflow_primitive {
+    ($type: ty, $num_slots: expr) => {
+        impl SlabItem for $type {
+            fn slab_size() -> usize {
+                $num_slots
+            }
+
+            fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+                if slab.len() >= index + $num_slots {
+                    *self = (0..$num_slots).fold(0, |acc, i| {
+                        acc | ((<$type>::from(slab[index + i])) << (i * 32))
+                    });
+                    index + $num_slots
+                } else {
+                    index
+                }
+            }
+
+            fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+                if slab.len() >= index + $num_slots {
+                    for i in 0..$num_slots {
+                        slab[index + i] = (*self >> (i * 32)) as u32;
+                    }
+                    index + $num_slots
+                } else {
+                    index
+                }
+            }
+        }
+    };
+}
+
+
+
+impl_underflow_primitive!(u8);
+impl_underflow_primitive!(i8);
+impl_underflow_primitive!(u16);
+impl_underflow_primitive!(i16);
+impl_underflow_primitive!(u32);
+impl_underflow_primitive!(i32);
+
+impl_overflow_primitive!(u64, 2);
+impl_overflow_primitive!(i64, 2);
+impl_overflow_primitive!(u128, 4);
+impl_overflow_primitive!(i128, 4);
+
+
+
+
+impl SlabItem for f32 {
+    fn slab_size() -> usize {
+        1
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        if slab.len() > index {
+            *self = f32::from_bits(slab[index]);
+            index + 1
+        } else {
+            index
+        }
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        if slab.len() > index {
+            slab[index] = self.to_bits();
+            index + 1
+        } else {
+            index
+        }
+    }
+}
+
+impl SlabItem for f64 {
+    fn slab_size() -> usize {
+        2
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let mut temp_u64 = 0u64;
+        let index = temp_u64.read_slab(index, slab);
+        *self = f64::from_bits(temp_u64);
+        index
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        let temp_u64 = self.to_bits();
+        temp_u64.write_slab(index, slab)
+    }
+}
+
+
+impl SlabItem for bool {
+    fn slab_size() -> usize {
+        1
+    }
+
+    fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+        let mut proxy = 0u32;
+        let index = proxy.read_slab(index, slab);
+        *self = proxy == 1;
+        index
+    }
+
+    fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+        if *self { 1u32 } else { 0u32 }.write_slab(index, slab)
+    }
+}

--- a/crates/crabslab/src/impl_slab_item/tuples.rs
+++ b/crates/crabslab/src/impl_slab_item/tuples.rs
@@ -1,0 +1,36 @@
+
+
+use crate::SlabItem;
+
+
+macro_rules! impl_tuples {
+
+    ($($generic: tt),+) => {
+        impl<$($generic),+,> SlabItem for ($($generic),+,)
+        where
+            $($generic: SlabItem),+,
+        {
+            fn slab_size() -> usize {
+                $($generic::slab_size() +)+ 0
+            }
+            fn read_slab(&mut self, index: usize, slab: &[u32]) -> usize {
+                $(${ignore(generic)} let index = self.${index()}.read_slab(index, slab);)+
+                index
+            }
+            fn write_slab(&self, index: usize, slab: &mut [u32]) -> usize {
+                $(${ignore(generic)} let index = self.${index()}.write_slab(index, slab);)+
+                index
+            }
+        }
+
+        impl_tuples!(@pop $($generic),+);
+    };
+
+    (@pop $_: tt, $($generic: tt),+) => {
+        impl_tuples!($($generic),+);
+    };
+    (@pop $_: tt) => {};
+}
+
+//Rust tuples only implement Default for up to 12 elements, as of now
+impl_tuples!(M, L, J, I, H, G, F, E, D, C, B, A);

--- a/crates/crabslab/src/lib.rs
+++ b/crates/crabslab/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(macro_metavar_expr)]
 #![cfg_attr(target_arch = "spirv", no_std)]
 //! Creating and crafting a tasty slab of memory.
 #![doc = include_str!("../README.md")]
@@ -15,5 +16,7 @@ pub use slab::*;
 mod wgpu_slab;
 #[cfg(feature = "wgpu")]
 pub use wgpu_slab::*;
+
+pub mod impl_slab_item;
 
 pub use crabslab_derive::SlabItem;


### PR DESCRIPTION
* Adds `SlabItem` impls for missing primitive types
* Adds `SlabItem` impls for tuples (up to 12) 
* Refactor by putting impls in specific files 

[Conversation in Embark's `rust-gpu` discord](https://discord.com/channels/750717012564770887/750717499737243679/1196897917269721118)