### PR TITLE
feat: add SlabItem support for all wgsl-rs vector and matrix types

### DIFF
--- a/crates/craballoc/Cargo.toml
+++ b/crates/craballoc/Cargo.toml
@@ -10,13 +10,14 @@ categories = ["rendering", "game-development", "graphics"]
 readme = "README.md"
 
 [features]
-default = ["wgpu"]
+default = ["wgpu", "wgsl-rs"]
 wgpu = ["dep:wgpu"]
+wgsl-rs = ["crabslab/wgsl-rs"]
 
 [dependencies]
 async-channel.workspace = true
 bytemuck.workspace = true
-crabslab = { path = "../crabslab", features = ["wgsl-rs"] }
+crabslab = { path = "../crabslab" }
 log.workspace = true
 rustc-hash.workspace = true
 snafu.workspace = true

--- a/crates/craballoc/Cargo.toml
+++ b/crates/craballoc/Cargo.toml
@@ -16,7 +16,7 @@ wgpu = ["dep:wgpu"]
 [dependencies]
 async-channel.workspace = true
 bytemuck.workspace = true
-crabslab = { path = "../crabslab" }
+crabslab = { path = "../crabslab", features = ["wgsl-rs"] }
 log.workspace = true
 rustc-hash.workspace = true
 snafu.workspace = true

--- a/crates/crabslab-macros/src/lib.rs
+++ b/crates/crabslab-macros/src/lib.rs
@@ -687,10 +687,25 @@ fn generate_slab_item_proxy(type_name: &syn::Ident) -> syn::Item {
 // ---------------------------------------------------------------------------
 
 /// Return a `TokenStream2` expression for the slab size of a field type.
-/// Primitives are inlined as literals; other types use `Type::SLAB_SIZE`.
+/// Primitives and wgsl-rs vector/matrix types are inlined as literals;
+/// other types use `Type::SLAB_SIZE`.
 fn field_slab_size_expr(ty: &syn::Type) -> TokenStream2 {
     match type_name_str(ty).as_deref() {
         Some("u32" | "i32" | "f32" | "bool") => quote! { 1usize },
+        // wgsl-rs vector types
+        Some("Vec2f" | "Vec2i" | "Vec2u" | "Vec2b") => quote! { 2usize },
+        Some("Vec3f" | "Vec3i" | "Vec3u" | "Vec3b") => quote! { 3usize },
+        Some("Vec4f" | "Vec4i" | "Vec4u" | "Vec4b") => quote! { 4usize },
+        // wgsl-rs matrix types
+        Some("Mat2x2f" | "Mat2f") => quote! { 4usize },
+        Some("Mat2x3f") => quote! { 6usize },
+        Some("Mat2x4f") => quote! { 8usize },
+        Some("Mat3x2f") => quote! { 6usize },
+        Some("Mat3x3f" | "Mat3f") => quote! { 9usize },
+        Some("Mat3x4f") => quote! { 12usize },
+        Some("Mat4x2f") => quote! { 8usize },
+        Some("Mat4x3f") => quote! { 12usize },
+        Some("Mat4x4f" | "Mat4f") => quote! { 16usize },
         _ => quote! { #ty::SLAB_SIZE },
     }
 }
@@ -699,10 +714,12 @@ fn field_slab_size_expr(ty: &syn::Type) -> TokenStream2 {
 /// field from a `u32s` array at the given offset.
 ///
 /// For primitive types the pre-statements are empty and the expression
-/// reads directly from `u32s`. For nested `#[slab_item]` types the
-/// pre-statements read a sub-array into a local variable so that the
-/// struct literal field can use a simple expression (WGSL does not
-/// support block expressions as struct field initializers).
+/// reads directly from `u32s`. For wgsl-rs vector/matrix types the
+/// pre-statements read components and construct the value. For nested
+/// `#[slab_item]` types the pre-statements read a sub-array into a
+/// local variable so that the struct literal field can use a simple
+/// expression (WGSL does not support block expressions as struct field
+/// initializers).
 fn field_from_array_parts(
     ty: &syn::Type,
     offset: &TokenStream2,
@@ -713,6 +730,162 @@ fn field_from_array_parts(
         Some("f32") => (vec![], quote! { bitcast_f32(u32s[#offset]) }),
         Some("i32") => (vec![], quote! { bitcast_i32(u32s[#offset]) }),
         Some("bool") => (vec![], quote! { u32s[#offset] != 0u32 }),
+
+        // -- wgsl-rs Vec2 types -------------------------------------------
+        Some("Vec2f") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec2f(
+                    bitcast_f32(u32s[#offset]),
+                    bitcast_f32(u32s[#offset + 1usize]),
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec2i") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec2i(
+                    bitcast_i32(u32s[#offset]),
+                    bitcast_i32(u32s[#offset + 1usize]),
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec2u") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec2u(
+                    u32s[#offset],
+                    u32s[#offset + 1usize],
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec2b") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec2b(
+                    u32s[#offset] != 0u32,
+                    u32s[#offset + 1usize] != 0u32,
+                );
+            }];
+            (pre, quote! { #val })
+        }
+
+        // -- wgsl-rs Vec3 types -------------------------------------------
+        Some("Vec3f") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec3f(
+                    bitcast_f32(u32s[#offset]),
+                    bitcast_f32(u32s[#offset + 1usize]),
+                    bitcast_f32(u32s[#offset + 2usize]),
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec3i") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec3i(
+                    bitcast_i32(u32s[#offset]),
+                    bitcast_i32(u32s[#offset + 1usize]),
+                    bitcast_i32(u32s[#offset + 2usize]),
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec3u") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec3u(
+                    u32s[#offset],
+                    u32s[#offset + 1usize],
+                    u32s[#offset + 2usize],
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec3b") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec3b(
+                    u32s[#offset] != 0u32,
+                    u32s[#offset + 1usize] != 0u32,
+                    u32s[#offset + 2usize] != 0u32,
+                );
+            }];
+            (pre, quote! { #val })
+        }
+
+        // -- wgsl-rs Vec4 types -------------------------------------------
+        Some("Vec4f") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec4f(
+                    bitcast_f32(u32s[#offset]),
+                    bitcast_f32(u32s[#offset + 1usize]),
+                    bitcast_f32(u32s[#offset + 2usize]),
+                    bitcast_f32(u32s[#offset + 3usize]),
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec4i") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec4i(
+                    bitcast_i32(u32s[#offset]),
+                    bitcast_i32(u32s[#offset + 1usize]),
+                    bitcast_i32(u32s[#offset + 2usize]),
+                    bitcast_i32(u32s[#offset + 3usize]),
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec4u") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec4u(
+                    u32s[#offset],
+                    u32s[#offset + 1usize],
+                    u32s[#offset + 2usize],
+                    u32s[#offset + 3usize],
+                );
+            }];
+            (pre, quote! { #val })
+        }
+        Some("Vec4b") => {
+            let val = format_ident!("val_{}", field_name);
+            let pre = vec![quote! {
+                let #val = vec4b(
+                    u32s[#offset] != 0u32,
+                    u32s[#offset + 1usize] != 0u32,
+                    u32s[#offset + 2usize] != 0u32,
+                    u32s[#offset + 3usize] != 0u32,
+                );
+            }];
+            (pre, quote! { #val })
+        }
+
+        // -- wgsl-rs matrix types -----------------------------------------
+        Some(name @ ("Mat2x2f" | "Mat2f")) => {
+            vec_matrix_from_array_parts(name, field_name, offset, 2, 2)
+        }
+        Some(name @ "Mat2x3f") => vec_matrix_from_array_parts(name, field_name, offset, 2, 3),
+        Some(name @ "Mat2x4f") => vec_matrix_from_array_parts(name, field_name, offset, 2, 4),
+        Some(name @ "Mat3x2f") => vec_matrix_from_array_parts(name, field_name, offset, 3, 2),
+        Some(name @ ("Mat3x3f" | "Mat3f")) => {
+            vec_matrix_from_array_parts(name, field_name, offset, 3, 3)
+        }
+        Some(name @ "Mat3x4f") => vec_matrix_from_array_parts(name, field_name, offset, 3, 4),
+        Some(name @ "Mat4x2f") => vec_matrix_from_array_parts(name, field_name, offset, 4, 2),
+        Some(name @ "Mat4x3f") => vec_matrix_from_array_parts(name, field_name, offset, 4, 3),
+        Some(name @ ("Mat4x4f" | "Mat4f")) => {
+            vec_matrix_from_array_parts(name, field_name, offset, 4, 4)
+        }
+
         _ => {
             // Nested slab_item type: generate pre-statements to read the
             // sub-array, then use the local variable in the struct literal.
@@ -725,6 +898,86 @@ fn field_from_array_parts(
             ];
             (pre, quote! { #val_ident })
         }
+    }
+}
+
+/// Generate pre-computation statements and a value expression to read a
+/// wgsl-rs matrix field from a `u32s` array.
+///
+/// Matrices are column-major. Each column is a `VecRf` with `rows`
+/// components. The matrix has `cols` columns.
+fn vec_matrix_from_array_parts(
+    _mat_name: &str,
+    field_name: &syn::Ident,
+    offset: &TokenStream2,
+    cols: usize,
+    rows: usize,
+) -> (Vec<TokenStream2>, TokenStream2) {
+    let val = format_ident!("val_{}", field_name);
+
+    // Generate column read expressions.
+    let col_exprs: Vec<TokenStream2> = (0..cols)
+        .map(|c| {
+            let col_offset = c * rows;
+            vec_read_expr(rows, offset, col_offset)
+        })
+        .collect();
+
+    // Pick the correct constructor name (e.g., mat3x4f).
+    let ctor = format_ident!("mat{}x{}f", cols, rows);
+
+    let pre = vec![quote! {
+        let #val = #ctor(#(#col_exprs),*);
+    }];
+
+    (pre, quote! { #val })
+}
+
+/// Generate a token stream expression that reads a `VecNf` from `u32s`
+/// at `base_offset + component_offset`.
+fn vec_read_expr(
+    components: usize,
+    base_offset: &TokenStream2,
+    component_offset: usize,
+) -> TokenStream2 {
+    match components {
+        2 => {
+            let o0 = component_offset;
+            let o1 = component_offset + 1;
+            quote! {
+                vec2f(
+                    bitcast_f32(u32s[#base_offset + #o0]),
+                    bitcast_f32(u32s[#base_offset + #o1]),
+                )
+            }
+        }
+        3 => {
+            let o0 = component_offset;
+            let o1 = component_offset + 1;
+            let o2 = component_offset + 2;
+            quote! {
+                vec3f(
+                    bitcast_f32(u32s[#base_offset + #o0]),
+                    bitcast_f32(u32s[#base_offset + #o1]),
+                    bitcast_f32(u32s[#base_offset + #o2]),
+                )
+            }
+        }
+        4 => {
+            let o0 = component_offset;
+            let o1 = component_offset + 1;
+            let o2 = component_offset + 2;
+            let o3 = component_offset + 3;
+            quote! {
+                vec4f(
+                    bitcast_f32(u32s[#base_offset + #o0]),
+                    bitcast_f32(u32s[#base_offset + #o1]),
+                    bitcast_f32(u32s[#base_offset + #o2]),
+                    bitcast_f32(u32s[#base_offset + #o3]),
+                )
+            }
+        }
+        _ => unreachable!("invalid vector component count: {components}"),
     }
 }
 
@@ -742,6 +995,84 @@ fn field_to_array_stmt(
         Some("bool") => {
             quote! { arr[#offset] = if d.#field_name { 1u32 } else { 0u32 }; }
         }
+
+        // -- wgsl-rs Vec2 types -------------------------------------------
+        Some("Vec2f") => quote! {
+            arr[#offset] = bitcast_u32(d.#field_name.x);
+            arr[#offset + 1usize] = bitcast_u32(d.#field_name.y);
+        },
+        Some("Vec2i") => quote! {
+            arr[#offset] = bitcast_u32(d.#field_name.x);
+            arr[#offset + 1usize] = bitcast_u32(d.#field_name.y);
+        },
+        Some("Vec2u") => quote! {
+            arr[#offset] = d.#field_name.x;
+            arr[#offset + 1usize] = d.#field_name.y;
+        },
+        Some("Vec2b") => quote! {
+            arr[#offset] = if d.#field_name.x { 1u32 } else { 0u32 };
+            arr[#offset + 1usize] = if d.#field_name.y { 1u32 } else { 0u32 };
+        },
+
+        // -- wgsl-rs Vec3 types -------------------------------------------
+        Some("Vec3f") => quote! {
+            arr[#offset] = bitcast_u32(d.#field_name.x);
+            arr[#offset + 1usize] = bitcast_u32(d.#field_name.y);
+            arr[#offset + 2usize] = bitcast_u32(d.#field_name.z);
+        },
+        Some("Vec3i") => quote! {
+            arr[#offset] = bitcast_u32(d.#field_name.x);
+            arr[#offset + 1usize] = bitcast_u32(d.#field_name.y);
+            arr[#offset + 2usize] = bitcast_u32(d.#field_name.z);
+        },
+        Some("Vec3u") => quote! {
+            arr[#offset] = d.#field_name.x;
+            arr[#offset + 1usize] = d.#field_name.y;
+            arr[#offset + 2usize] = d.#field_name.z;
+        },
+        Some("Vec3b") => quote! {
+            arr[#offset] = if d.#field_name.x { 1u32 } else { 0u32 };
+            arr[#offset + 1usize] = if d.#field_name.y { 1u32 } else { 0u32 };
+            arr[#offset + 2usize] = if d.#field_name.z { 1u32 } else { 0u32 };
+        },
+
+        // -- wgsl-rs Vec4 types -------------------------------------------
+        Some("Vec4f") => quote! {
+            arr[#offset] = bitcast_u32(d.#field_name.x);
+            arr[#offset + 1usize] = bitcast_u32(d.#field_name.y);
+            arr[#offset + 2usize] = bitcast_u32(d.#field_name.z);
+            arr[#offset + 3usize] = bitcast_u32(d.#field_name.w);
+        },
+        Some("Vec4i") => quote! {
+            arr[#offset] = bitcast_u32(d.#field_name.x);
+            arr[#offset + 1usize] = bitcast_u32(d.#field_name.y);
+            arr[#offset + 2usize] = bitcast_u32(d.#field_name.z);
+            arr[#offset + 3usize] = bitcast_u32(d.#field_name.w);
+        },
+        Some("Vec4u") => quote! {
+            arr[#offset] = d.#field_name.x;
+            arr[#offset + 1usize] = d.#field_name.y;
+            arr[#offset + 2usize] = d.#field_name.z;
+            arr[#offset + 3usize] = d.#field_name.w;
+        },
+        Some("Vec4b") => quote! {
+            arr[#offset] = if d.#field_name.x { 1u32 } else { 0u32 };
+            arr[#offset + 1usize] = if d.#field_name.y { 1u32 } else { 0u32 };
+            arr[#offset + 2usize] = if d.#field_name.z { 1u32 } else { 0u32 };
+            arr[#offset + 3usize] = if d.#field_name.w { 1u32 } else { 0u32 };
+        },
+
+        // -- wgsl-rs matrix types -----------------------------------------
+        Some("Mat2x2f" | "Mat2f") => vec_matrix_to_array_stmt(field_name, offset, 2, 2),
+        Some("Mat2x3f") => vec_matrix_to_array_stmt(field_name, offset, 2, 3),
+        Some("Mat2x4f") => vec_matrix_to_array_stmt(field_name, offset, 2, 4),
+        Some("Mat3x2f") => vec_matrix_to_array_stmt(field_name, offset, 3, 2),
+        Some("Mat3x3f" | "Mat3f") => vec_matrix_to_array_stmt(field_name, offset, 3, 3),
+        Some("Mat3x4f") => vec_matrix_to_array_stmt(field_name, offset, 3, 4),
+        Some("Mat4x2f") => vec_matrix_to_array_stmt(field_name, offset, 4, 2),
+        Some("Mat4x3f") => vec_matrix_to_array_stmt(field_name, offset, 4, 3),
+        Some("Mat4x4f" | "Mat4f") => vec_matrix_to_array_stmt(field_name, offset, 4, 4),
+
         _ => {
             // Nested slab_item type: copy sub-array via slab_write_array!.
             quote! {
@@ -752,6 +1083,59 @@ fn field_to_array_stmt(
             }
         }
     }
+}
+
+/// Generate statements to write a wgsl-rs matrix field into an `arr` array.
+///
+/// Matrices are column-major. Each column is accessed via `d.field[col_idx]`
+/// and each component is bitcast to u32.
+fn vec_matrix_to_array_stmt(
+    field_name: &syn::Ident,
+    offset: &TokenStream2,
+    cols: usize,
+    rows: usize,
+) -> TokenStream2 {
+    let mut stmts = Vec::new();
+
+    for c in 0..cols {
+        let col_base = c * rows;
+        let col_idx = c;
+        match rows {
+            2 => {
+                let o0 = col_base;
+                let o1 = col_base + 1;
+                stmts.push(quote! {
+                    arr[#offset + #o0] = bitcast_u32(d.#field_name[#col_idx].x);
+                    arr[#offset + #o1] = bitcast_u32(d.#field_name[#col_idx].y);
+                });
+            }
+            3 => {
+                let o0 = col_base;
+                let o1 = col_base + 1;
+                let o2 = col_base + 2;
+                stmts.push(quote! {
+                    arr[#offset + #o0] = bitcast_u32(d.#field_name[#col_idx].x);
+                    arr[#offset + #o1] = bitcast_u32(d.#field_name[#col_idx].y);
+                    arr[#offset + #o2] = bitcast_u32(d.#field_name[#col_idx].z);
+                });
+            }
+            4 => {
+                let o0 = col_base;
+                let o1 = col_base + 1;
+                let o2 = col_base + 2;
+                let o3 = col_base + 3;
+                stmts.push(quote! {
+                    arr[#offset + #o0] = bitcast_u32(d.#field_name[#col_idx].x);
+                    arr[#offset + #o1] = bitcast_u32(d.#field_name[#col_idx].y);
+                    arr[#offset + #o2] = bitcast_u32(d.#field_name[#col_idx].z);
+                    arr[#offset + #o3] = bitcast_u32(d.#field_name[#col_idx].w);
+                });
+            }
+            _ => unreachable!("invalid matrix row count: {rows}"),
+        }
+    }
+
+    quote! { #(#stmts)* }
 }
 
 /// Build cumulative offset expressions for each field in a struct.

--- a/crates/crabslab/Cargo.toml
+++ b/crates/crabslab/Cargo.toml
@@ -6,8 +6,13 @@ description = "Slab allocator for CPU/GPU data marshalling via wgsl-rs"
 repository = "https://github.com/schell/crabslab"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = []
+wgsl-rs = ["dep:wgsl-rs"]
+
 [dependencies]
 crabslab-macros = { path = "../crabslab-macros" }
+wgsl-rs = { workspace = true, optional = true }
 
 [dev-dependencies]
 wgsl-rs = { workspace = true }

--- a/crates/crabslab/src/lib.rs
+++ b/crates/crabslab/src/lib.rs
@@ -19,6 +19,9 @@ pub extern crate self as crabslab;
 
 pub use crabslab_macros::{slab_item, slab_module};
 
+#[cfg(feature = "wgsl-rs")]
+mod wgsl_rs_types;
+
 /// CPU-side trait for types that can be stored in a `u32` slab.
 ///
 /// Auto-implemented by the `#[slab_module]` macro for `#[slab_item]` types.
@@ -706,5 +709,238 @@ pub mod test {
         slab_write!(Data, slab, 4, d);
         let d3 = slab_read!(Data, slab, 4);
         assert_eq!(d, d3);
+    }
+
+    // -----------------------------------------------------------------------
+    // #[slab_module] integration tests for wgsl-rs vector/matrix fields
+    // -----------------------------------------------------------------------
+
+    #[slab_module]
+    mod test_vec_fields {
+        #[slab_item]
+        #[derive(Clone, Copy, Debug, Default, PartialEq)]
+        pub struct VecData {
+            pub pos: Vec3f,
+            pub uv: Vec2f,
+            pub color: Vec4f,
+        }
+
+        #[slab_item]
+        #[derive(Clone, Copy, Debug, Default, PartialEq)]
+        pub struct IntVecData {
+            pub a: Vec2i,
+            pub b: Vec3u,
+            pub c: Vec4b,
+        }
+    }
+
+    #[test]
+    fn vec_field_slab_sizes() {
+        // VecData: Vec3f(3) + Vec2f(2) + Vec4f(4) = 9.
+        assert_eq!(9, test_vec_fields::VecData::SLAB_SIZE);
+        assert_eq!(9, <test_vec_fields::VecData as SlabItem>::SLAB_SIZE);
+
+        // IntVecData: Vec2i(2) + Vec3u(3) + Vec4b(4) = 9.
+        assert_eq!(9, test_vec_fields::IntVecData::SLAB_SIZE);
+    }
+
+    #[test]
+    fn vec_field_round_trip() {
+        use wgsl_rs::std::*;
+
+        let d = test_vec_fields::VecData {
+            pos: vec3f(1.0, 2.0, 3.0),
+            uv: vec2f(0.5, 0.75),
+            color: vec4f(0.1, 0.2, 0.3, 1.0),
+        };
+        let arr = test_vec_fields::VecData::to_array(d);
+        let d2 = test_vec_fields::VecData::from_array(arr);
+        assert_eq!(d, d2);
+
+        // Via slab.
+        let mut slab = [0u32; 18];
+        slab_write(&mut slab, 0, &d);
+        let d3: test_vec_fields::VecData = slab_read(&slab, 0);
+        assert_eq!(d, d3);
+
+        // Non-zero offset.
+        slab_write(&mut slab, 9, &d);
+        let d4: test_vec_fields::VecData = slab_read(&slab, 9);
+        assert_eq!(d, d4);
+    }
+
+    #[test]
+    fn vec_field_raw_layout() {
+        use wgsl_rs::std::*;
+
+        let d = test_vec_fields::VecData {
+            pos: vec3f(1.0, 2.0, 3.0),
+            uv: vec2f(4.0, 5.0),
+            color: vec4f(6.0, 7.0, 8.0, 9.0),
+        };
+        let arr = test_vec_fields::VecData::to_array(d);
+        // pos: [1.0, 2.0, 3.0], uv: [4.0, 5.0], color: [6.0, 7.0, 8.0,
+        // 9.0]
+        for i in 0..9 {
+            assert_eq!(((i + 1) as f32).to_bits(), arr[i], "mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn int_vec_field_round_trip() {
+        use wgsl_rs::std::*;
+
+        let d = test_vec_fields::IntVecData {
+            a: vec2i(-1, 42),
+            b: vec3u(10, 20, 30),
+            c: vec4b(true, false, true, false),
+        };
+        let arr = test_vec_fields::IntVecData::to_array(d);
+        let d2 = test_vec_fields::IntVecData::from_array(arr);
+        assert_eq!(d, d2);
+
+        let mut slab = [0u32; 18];
+        slab_write(&mut slab, 0, &d);
+        let d3: test_vec_fields::IntVecData = slab_read(&slab, 0);
+        assert_eq!(d, d3);
+    }
+
+    #[slab_module]
+    mod test_mat_fields {
+        // Note: matrix types in wgsl-rs don't derive Debug or PartialEq,
+        // so structs containing them can't derive those traits either.
+        #[slab_item]
+        #[derive(Clone, Copy, Default)]
+        pub struct MatData {
+            pub transform: Mat4x4f,
+            pub normal: Mat3x3f,
+        }
+
+        #[slab_item]
+        #[derive(Clone, Copy, Default)]
+        pub struct MixedData {
+            pub scale: f32,
+            pub offset: Vec3f,
+            pub matrix: Mat2x2f,
+            pub flags: u32,
+        }
+    }
+
+    #[test]
+    fn mat_field_slab_sizes() {
+        // MatData: Mat4x4f(16) + Mat3x3f(9) = 25.
+        assert_eq!(25, test_mat_fields::MatData::SLAB_SIZE);
+
+        // MixedData: f32(1) + Vec3f(3) + Mat2x2f(4) + u32(1) = 9.
+        assert_eq!(9, test_mat_fields::MixedData::SLAB_SIZE);
+    }
+
+    #[test]
+    fn mat_field_round_trip() {
+        use wgsl_rs::std::*;
+
+        let d = test_mat_fields::MatData {
+            transform: mat4x4f(
+                vec4f(1.0, 0.0, 0.0, 0.0),
+                vec4f(0.0, 1.0, 0.0, 0.0),
+                vec4f(0.0, 0.0, 1.0, 0.0),
+                vec4f(0.0, 0.0, 0.0, 1.0),
+            ),
+            normal: mat3x3f(
+                vec3f(1.0, 0.0, 0.0),
+                vec3f(0.0, 1.0, 0.0),
+                vec3f(0.0, 0.0, 1.0),
+            ),
+        };
+        let arr = test_mat_fields::MatData::to_array(d);
+        let d2 = test_mat_fields::MatData::from_array(arr);
+        assert_eq!(d.transform[0usize], d2.transform[0usize]);
+        assert_eq!(d.transform[1usize], d2.transform[1usize]);
+        assert_eq!(d.transform[2usize], d2.transform[2usize]);
+        assert_eq!(d.transform[3usize], d2.transform[3usize]);
+        assert_eq!(d.normal[0usize], d2.normal[0usize]);
+        assert_eq!(d.normal[1usize], d2.normal[1usize]);
+        assert_eq!(d.normal[2usize], d2.normal[2usize]);
+
+        // Via slab.
+        let mut slab = [0u32; 50];
+        slab_write(&mut slab, 0, &d);
+        let d3: test_mat_fields::MatData = slab_read(&slab, 0);
+        assert_eq!(d.transform[0usize], d3.transform[0usize]);
+        assert_eq!(d.transform[3usize], d3.transform[3usize]);
+        assert_eq!(d.normal[2usize], d3.normal[2usize]);
+    }
+
+    #[test]
+    fn mixed_field_round_trip() {
+        use wgsl_rs::std::*;
+
+        let d = test_mat_fields::MixedData {
+            scale: 2.5,
+            offset: vec3f(10.0, 20.0, 30.0),
+            matrix: mat2x2f(vec2f(1.0, 0.0), vec2f(0.0, 1.0)),
+            flags: 0xFF,
+        };
+        let arr = test_mat_fields::MixedData::to_array(d);
+        let d2 = test_mat_fields::MixedData::from_array(arr);
+        assert_eq!(d.scale, d2.scale);
+        assert_eq!(d.offset, d2.offset);
+        assert_eq!(d.matrix[0usize], d2.matrix[0usize]);
+        assert_eq!(d.matrix[1usize], d2.matrix[1usize]);
+        assert_eq!(d.flags, d2.flags);
+
+        // Via slab.
+        let mut slab = [0u32; 18];
+        slab_write(&mut slab, 0, &d);
+        let d3: test_mat_fields::MixedData = slab_read(&slab, 0);
+        assert_eq!(d.scale, d3.scale);
+        assert_eq!(d.offset, d3.offset);
+        assert_eq!(d.flags, d3.flags);
+    }
+
+    #[slab_module(wgsl())]
+    mod wgsl_vec_test {
+        #[slab_item]
+        #[derive(Clone, Copy, Debug, Default, PartialEq)]
+        pub struct Vertex {
+            pub position: Vec3f,
+            pub normal: Vec3f,
+            pub uv: Vec2f,
+        }
+    }
+
+    #[test]
+    fn wgsl_vec_module_is_generated() {
+        let source = wgsl_vec_test::WGSL_MODULE.wgsl_source();
+        assert!(!source.is_empty(), "WGSL source should not be empty");
+    }
+
+    #[test]
+    fn wgsl_vec_module_contains_struct() {
+        let source = wgsl_vec_test::WGSL_MODULE.wgsl_source();
+        let source_str = source.join("\n");
+        assert!(
+            source_str.contains("struct Vertex"),
+            "WGSL source should contain 'struct Vertex', got:\n{source_str}"
+        );
+    }
+
+    #[test]
+    fn wgsl_vec_types_work_on_cpu() {
+        use wgsl_rs::std::*;
+
+        let v = wgsl_vec_test::Vertex {
+            position: vec3f(1.0, 2.0, 3.0),
+            normal: vec3f(0.0, 1.0, 0.0),
+            uv: vec2f(0.5, 0.5),
+        };
+        let arr = wgsl_vec_test::Vertex::to_array(v);
+        let v2 = wgsl_vec_test::Vertex::from_array(arr);
+        assert_eq!(v, v2);
+
+        let mut slab = [0u32; 16];
+        slab_write(&mut slab, 0, &v);
+        let v3: wgsl_vec_test::Vertex = slab_read(&slab, 0);
+        assert_eq!(v, v3);
     }
 }

--- a/crates/crabslab/src/wgsl_rs_types.rs
+++ b/crates/crabslab/src/wgsl_rs_types.rs
@@ -1,0 +1,994 @@
+//! [`SlabItem`] implementations for `wgsl-rs` vector and matrix types.
+//!
+//! This module is conditionally compiled when the `wgsl-rs` feature is
+//! enabled. It provides [`SlabItem`] for all 12 concrete vector types
+//! and all 9 matrix types defined in `wgsl_rs::std`.
+//!
+//! ## Vector types
+//!
+//! | Type   | Element | SLAB_SIZE |
+//! |--------|---------|-----------|
+//! | Vec2f  | f32     | 2         |
+//! | Vec3f  | f32     | 3         |
+//! | Vec4f  | f32     | 4         |
+//! | Vec2i  | i32     | 2         |
+//! | Vec3i  | i32     | 3         |
+//! | Vec4i  | i32     | 4         |
+//! | Vec2u  | u32     | 2         |
+//! | Vec3u  | u32     | 3         |
+//! | Vec4u  | u32     | 4         |
+//! | Vec2b  | bool    | 2         |
+//! | Vec3b  | bool    | 3         |
+//! | Vec4b  | bool    | 4         |
+//!
+//! ## Matrix types
+//!
+//! All matrices are f32-only and column-major.
+//!
+//! | Type     | Columns | Row size | SLAB_SIZE |
+//! |----------|---------|----------|-----------|
+//! | Mat2x2f  | 2       | 2        | 4         |
+//! | Mat2x3f  | 2       | 3        | 6         |
+//! | Mat2x4f  | 2       | 4        | 8         |
+//! | Mat3x2f  | 3       | 2        | 6         |
+//! | Mat3x3f  | 3       | 3        | 9         |
+//! | Mat3x4f  | 3       | 4        | 12        |
+//! | Mat4x2f  | 4       | 2        | 8         |
+//! | Mat4x3f  | 4       | 3        | 12        |
+//! | Mat4x4f  | 4       | 4        | 16        |
+//!
+//! The type aliases `Mat2f`, `Mat3f`, `Mat4f` are re-exports of
+//! `Mat2x2f`, `Mat3x3f`, `Mat4x4f` and inherit their impls automatically.
+
+use wgsl_rs::std::{
+    Mat2x2f, Mat2x3f, Mat2x4f, Mat3x2f, Mat3x3f, Mat3x4f, Mat4x2f, Mat4x3f, Mat4x4f, Vec2, Vec3,
+    Vec4,
+};
+
+use crate::SlabItem;
+
+// ---------------------------------------------------------------------------
+// Helper: f32 component serialization
+// ---------------------------------------------------------------------------
+
+#[inline]
+fn f32_to_u32(v: f32) -> u32 {
+    v.to_bits()
+}
+
+#[inline]
+fn u32_to_f32(v: u32) -> f32 {
+    f32::from_bits(v)
+}
+
+// ---------------------------------------------------------------------------
+// Vec2<f32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec2<f32> {
+    const SLAB_SIZE: usize = 2;
+    type Array = [u32; 2];
+
+    fn to_array(&self) -> [u32; 2] {
+        [f32_to_u32(self.x), f32_to_u32(self.y)]
+    }
+
+    fn from_array(arr: [u32; 2]) -> Self {
+        Vec2 {
+            x: u32_to_f32(arr[0]),
+            y: u32_to_f32(arr[1]),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec3<f32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec3<f32> {
+    const SLAB_SIZE: usize = 3;
+    type Array = [u32; 3];
+
+    fn to_array(&self) -> [u32; 3] {
+        [f32_to_u32(self.x), f32_to_u32(self.y), f32_to_u32(self.z)]
+    }
+
+    fn from_array(arr: [u32; 3]) -> Self {
+        Vec3 {
+            x: u32_to_f32(arr[0]),
+            y: u32_to_f32(arr[1]),
+            z: u32_to_f32(arr[2]),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec4<f32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec4<f32> {
+    const SLAB_SIZE: usize = 4;
+    type Array = [u32; 4];
+
+    fn to_array(&self) -> [u32; 4] {
+        [
+            f32_to_u32(self.x),
+            f32_to_u32(self.y),
+            f32_to_u32(self.z),
+            f32_to_u32(self.w),
+        ]
+    }
+
+    fn from_array(arr: [u32; 4]) -> Self {
+        Vec4 {
+            x: u32_to_f32(arr[0]),
+            y: u32_to_f32(arr[1]),
+            z: u32_to_f32(arr[2]),
+            w: u32_to_f32(arr[3]),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec2<i32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec2<i32> {
+    const SLAB_SIZE: usize = 2;
+    type Array = [u32; 2];
+
+    fn to_array(&self) -> [u32; 2] {
+        [self.x as u32, self.y as u32]
+    }
+
+    fn from_array(arr: [u32; 2]) -> Self {
+        Vec2 {
+            x: arr[0] as i32,
+            y: arr[1] as i32,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec3<i32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec3<i32> {
+    const SLAB_SIZE: usize = 3;
+    type Array = [u32; 3];
+
+    fn to_array(&self) -> [u32; 3] {
+        [self.x as u32, self.y as u32, self.z as u32]
+    }
+
+    fn from_array(arr: [u32; 3]) -> Self {
+        Vec3 {
+            x: arr[0] as i32,
+            y: arr[1] as i32,
+            z: arr[2] as i32,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec4<i32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec4<i32> {
+    const SLAB_SIZE: usize = 4;
+    type Array = [u32; 4];
+
+    fn to_array(&self) -> [u32; 4] {
+        [self.x as u32, self.y as u32, self.z as u32, self.w as u32]
+    }
+
+    fn from_array(arr: [u32; 4]) -> Self {
+        Vec4 {
+            x: arr[0] as i32,
+            y: arr[1] as i32,
+            z: arr[2] as i32,
+            w: arr[3] as i32,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec2<u32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec2<u32> {
+    const SLAB_SIZE: usize = 2;
+    type Array = [u32; 2];
+
+    fn to_array(&self) -> [u32; 2] {
+        [self.x, self.y]
+    }
+
+    fn from_array(arr: [u32; 2]) -> Self {
+        Vec2 {
+            x: arr[0],
+            y: arr[1],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec3<u32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec3<u32> {
+    const SLAB_SIZE: usize = 3;
+    type Array = [u32; 3];
+
+    fn to_array(&self) -> [u32; 3] {
+        [self.x, self.y, self.z]
+    }
+
+    fn from_array(arr: [u32; 3]) -> Self {
+        Vec3 {
+            x: arr[0],
+            y: arr[1],
+            z: arr[2],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec4<u32>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec4<u32> {
+    const SLAB_SIZE: usize = 4;
+    type Array = [u32; 4];
+
+    fn to_array(&self) -> [u32; 4] {
+        [self.x, self.y, self.z, self.w]
+    }
+
+    fn from_array(arr: [u32; 4]) -> Self {
+        Vec4 {
+            x: arr[0],
+            y: arr[1],
+            z: arr[2],
+            w: arr[3],
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec2<bool>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec2<bool> {
+    const SLAB_SIZE: usize = 2;
+    type Array = [u32; 2];
+
+    fn to_array(&self) -> [u32; 2] {
+        [
+            if self.x { 1u32 } else { 0u32 },
+            if self.y { 1u32 } else { 0u32 },
+        ]
+    }
+
+    fn from_array(arr: [u32; 2]) -> Self {
+        Vec2 {
+            x: arr[0] != 0,
+            y: arr[1] != 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec3<bool>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec3<bool> {
+    const SLAB_SIZE: usize = 3;
+    type Array = [u32; 3];
+
+    fn to_array(&self) -> [u32; 3] {
+        [
+            if self.x { 1u32 } else { 0u32 },
+            if self.y { 1u32 } else { 0u32 },
+            if self.z { 1u32 } else { 0u32 },
+        ]
+    }
+
+    fn from_array(arr: [u32; 3]) -> Self {
+        Vec3 {
+            x: arr[0] != 0,
+            y: arr[1] != 0,
+            z: arr[2] != 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Vec4<bool>
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Vec4<bool> {
+    const SLAB_SIZE: usize = 4;
+    type Array = [u32; 4];
+
+    fn to_array(&self) -> [u32; 4] {
+        [
+            if self.x { 1u32 } else { 0u32 },
+            if self.y { 1u32 } else { 0u32 },
+            if self.z { 1u32 } else { 0u32 },
+            if self.w { 1u32 } else { 0u32 },
+        ]
+    }
+
+    fn from_array(arr: [u32; 4]) -> Self {
+        Vec4 {
+            x: arr[0] != 0,
+            y: arr[1] != 0,
+            z: arr[2] != 0,
+            w: arr[3] != 0,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Matrix helper: serialize/deserialize columns of f32 vectors
+// ---------------------------------------------------------------------------
+
+/// Write a `Vec2<f32>` column into a `u32` slice at `offset`.
+#[inline]
+fn write_vec2f(arr: &mut [u32], offset: usize, v: &Vec2<f32>) {
+    arr[offset] = f32_to_u32(v.x);
+    arr[offset + 1] = f32_to_u32(v.y);
+}
+
+/// Read a `Vec2<f32>` column from a `u32` slice at `offset`.
+#[inline]
+fn read_vec2f(arr: &[u32], offset: usize) -> Vec2<f32> {
+    Vec2 {
+        x: u32_to_f32(arr[offset]),
+        y: u32_to_f32(arr[offset + 1]),
+    }
+}
+
+/// Write a `Vec3<f32>` column into a `u32` slice at `offset`.
+#[inline]
+fn write_vec3f(arr: &mut [u32], offset: usize, v: &Vec3<f32>) {
+    arr[offset] = f32_to_u32(v.x);
+    arr[offset + 1] = f32_to_u32(v.y);
+    arr[offset + 2] = f32_to_u32(v.z);
+}
+
+/// Read a `Vec3<f32>` column from a `u32` slice at `offset`.
+#[inline]
+fn read_vec3f(arr: &[u32], offset: usize) -> Vec3<f32> {
+    Vec3 {
+        x: u32_to_f32(arr[offset]),
+        y: u32_to_f32(arr[offset + 1]),
+        z: u32_to_f32(arr[offset + 2]),
+    }
+}
+
+/// Write a `Vec4<f32>` column into a `u32` slice at `offset`.
+#[inline]
+fn write_vec4f(arr: &mut [u32], offset: usize, v: &Vec4<f32>) {
+    arr[offset] = f32_to_u32(v.x);
+    arr[offset + 1] = f32_to_u32(v.y);
+    arr[offset + 2] = f32_to_u32(v.z);
+    arr[offset + 3] = f32_to_u32(v.w);
+}
+
+/// Read a `Vec4<f32>` column from a `u32` slice at `offset`.
+#[inline]
+fn read_vec4f(arr: &[u32], offset: usize) -> Vec4<f32> {
+    Vec4 {
+        x: u32_to_f32(arr[offset]),
+        y: u32_to_f32(arr[offset + 1]),
+        z: u32_to_f32(arr[offset + 2]),
+        w: u32_to_f32(arr[offset + 3]),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat2x2f (2 columns of Vec2f, 4 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat2x2f {
+    const SLAB_SIZE: usize = 4;
+    type Array = [u32; 4];
+
+    fn to_array(&self) -> [u32; 4] {
+        let mut arr = [0u32; 4];
+        write_vec2f(&mut arr, 0, &self[0usize]);
+        write_vec2f(&mut arr, 2, &self[1usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 4]) -> Self {
+        wgsl_rs::std::mat2x2f(read_vec2f(&arr, 0), read_vec2f(&arr, 2))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat2x3f (2 columns of Vec3f, 6 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat2x3f {
+    const SLAB_SIZE: usize = 6;
+    type Array = [u32; 6];
+
+    fn to_array(&self) -> [u32; 6] {
+        let mut arr = [0u32; 6];
+        write_vec3f(&mut arr, 0, &self[0usize]);
+        write_vec3f(&mut arr, 3, &self[1usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 6]) -> Self {
+        wgsl_rs::std::mat2x3f(read_vec3f(&arr, 0), read_vec3f(&arr, 3))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat2x4f (2 columns of Vec4f, 8 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat2x4f {
+    const SLAB_SIZE: usize = 8;
+    type Array = [u32; 8];
+
+    fn to_array(&self) -> [u32; 8] {
+        let mut arr = [0u32; 8];
+        write_vec4f(&mut arr, 0, &self[0usize]);
+        write_vec4f(&mut arr, 4, &self[1usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 8]) -> Self {
+        wgsl_rs::std::mat2x4f(read_vec4f(&arr, 0), read_vec4f(&arr, 4))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat3x2f (3 columns of Vec2f, 6 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat3x2f {
+    const SLAB_SIZE: usize = 6;
+    type Array = [u32; 6];
+
+    fn to_array(&self) -> [u32; 6] {
+        let mut arr = [0u32; 6];
+        write_vec2f(&mut arr, 0, &self[0usize]);
+        write_vec2f(&mut arr, 2, &self[1usize]);
+        write_vec2f(&mut arr, 4, &self[2usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 6]) -> Self {
+        wgsl_rs::std::mat3x2f(
+            read_vec2f(&arr, 0),
+            read_vec2f(&arr, 2),
+            read_vec2f(&arr, 4),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat3x3f (3 columns of Vec3f, 9 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat3x3f {
+    const SLAB_SIZE: usize = 9;
+    type Array = [u32; 9];
+
+    fn to_array(&self) -> [u32; 9] {
+        let mut arr = [0u32; 9];
+        write_vec3f(&mut arr, 0, &self[0usize]);
+        write_vec3f(&mut arr, 3, &self[1usize]);
+        write_vec3f(&mut arr, 6, &self[2usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 9]) -> Self {
+        wgsl_rs::std::mat3x3f(
+            read_vec3f(&arr, 0),
+            read_vec3f(&arr, 3),
+            read_vec3f(&arr, 6),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat3x4f (3 columns of Vec4f, 12 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat3x4f {
+    const SLAB_SIZE: usize = 12;
+    type Array = [u32; 12];
+
+    fn to_array(&self) -> [u32; 12] {
+        let mut arr = [0u32; 12];
+        write_vec4f(&mut arr, 0, &self[0usize]);
+        write_vec4f(&mut arr, 4, &self[1usize]);
+        write_vec4f(&mut arr, 8, &self[2usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 12]) -> Self {
+        wgsl_rs::std::mat3x4f(
+            read_vec4f(&arr, 0),
+            read_vec4f(&arr, 4),
+            read_vec4f(&arr, 8),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat4x2f (4 columns of Vec2f, 8 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat4x2f {
+    const SLAB_SIZE: usize = 8;
+    type Array = [u32; 8];
+
+    fn to_array(&self) -> [u32; 8] {
+        let mut arr = [0u32; 8];
+        write_vec2f(&mut arr, 0, &self[0usize]);
+        write_vec2f(&mut arr, 2, &self[1usize]);
+        write_vec2f(&mut arr, 4, &self[2usize]);
+        write_vec2f(&mut arr, 6, &self[3usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 8]) -> Self {
+        wgsl_rs::std::mat4x2f(
+            read_vec2f(&arr, 0),
+            read_vec2f(&arr, 2),
+            read_vec2f(&arr, 4),
+            read_vec2f(&arr, 6),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat4x3f (4 columns of Vec3f, 12 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat4x3f {
+    const SLAB_SIZE: usize = 12;
+    type Array = [u32; 12];
+
+    fn to_array(&self) -> [u32; 12] {
+        let mut arr = [0u32; 12];
+        write_vec3f(&mut arr, 0, &self[0usize]);
+        write_vec3f(&mut arr, 3, &self[1usize]);
+        write_vec3f(&mut arr, 6, &self[2usize]);
+        write_vec3f(&mut arr, 9, &self[3usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 12]) -> Self {
+        wgsl_rs::std::mat4x3f(
+            read_vec3f(&arr, 0),
+            read_vec3f(&arr, 3),
+            read_vec3f(&arr, 6),
+            read_vec3f(&arr, 9),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mat4x4f (4 columns of Vec4f, 16 u32 slots)
+// ---------------------------------------------------------------------------
+
+impl SlabItem for Mat4x4f {
+    const SLAB_SIZE: usize = 16;
+    type Array = [u32; 16];
+
+    fn to_array(&self) -> [u32; 16] {
+        let mut arr = [0u32; 16];
+        write_vec4f(&mut arr, 0, &self[0usize]);
+        write_vec4f(&mut arr, 4, &self[1usize]);
+        write_vec4f(&mut arr, 8, &self[2usize]);
+        write_vec4f(&mut arr, 12, &self[3usize]);
+        arr
+    }
+
+    fn from_array(arr: [u32; 16]) -> Self {
+        wgsl_rs::std::mat4x4f(
+            read_vec4f(&arr, 0),
+            read_vec4f(&arr, 4),
+            read_vec4f(&arr, 8),
+            read_vec4f(&arr, 12),
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{slab_read, slab_write};
+    use wgsl_rs::std::*;
+
+    /// Helper: round-trip a value through SlabItem's `to_array`/`from_array`.
+    fn rt<T: SlabItem + Copy>(v: &T) -> T {
+        T::from_array(v.to_array())
+    }
+
+    // -- Vector round-trip tests ------------------------------------------
+
+    #[test]
+    fn vec2f_round_trip() {
+        let v = vec2f(1.0, -2.5);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 4];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec2<f32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+
+        // Non-zero offset.
+        slab_write(&mut slab, 2, &v);
+        let v4: Vec2<f32> = slab_read(&slab, 2);
+        assert_eq!(v, v4);
+    }
+
+    #[test]
+    fn vec3f_round_trip() {
+        let v = vec3f(3.14, 0.0, -1.0);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 6];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec3<f32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+
+        slab_write(&mut slab, 3, &v);
+        let v4: Vec3<f32> = slab_read(&slab, 3);
+        assert_eq!(v, v4);
+    }
+
+    #[test]
+    fn vec4f_round_trip() {
+        let v = vec4f(1.0, 2.0, 3.0, 4.0);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 8];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec4<f32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+
+        slab_write(&mut slab, 4, &v);
+        let v4: Vec4<f32> = slab_read(&slab, 4);
+        assert_eq!(v, v4);
+    }
+
+    #[test]
+    fn vec2i_round_trip() {
+        let v = vec2i(-1, 42);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 4];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec2<i32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec3i_round_trip() {
+        let v = vec3i(i32::MIN, 0, i32::MAX);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 6];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec3<i32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec4i_round_trip() {
+        let v = vec4i(-100, 0, 100, -1);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 8];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec4<i32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec2u_round_trip() {
+        let v = vec2u(0, u32::MAX);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 4];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec2<u32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec3u_round_trip() {
+        let v = vec3u(1, 2, 3);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 6];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec3<u32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec4u_round_trip() {
+        let v = vec4u(10, 20, 30, 40);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 8];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec4<u32> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec2b_round_trip() {
+        let v = vec2b(true, false);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 4];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec2<bool> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec3b_round_trip() {
+        let v = vec3b(false, true, false);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 6];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec3<bool> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    #[test]
+    fn vec4b_round_trip() {
+        let v = vec4b(true, true, false, true);
+        assert_eq!(v, rt(&v));
+
+        let mut slab = [0u32; 8];
+        slab_write(&mut slab, 0, &v);
+        let v3: Vec4<bool> = slab_read(&slab, 0);
+        assert_eq!(v, v3);
+    }
+
+    // -- Vector edge cases ------------------------------------------------
+
+    #[test]
+    fn vec_f32_special_values() {
+        // NaN, infinity, negative zero.
+        let v = vec4f(f32::NAN, f32::INFINITY, f32::NEG_INFINITY, -0.0);
+        let v2 = rt(&v);
+        assert!(v2.x.is_nan());
+        assert_eq!(f32::INFINITY, v2.y);
+        assert_eq!(f32::NEG_INFINITY, v2.z);
+        assert_eq!((-0.0f32).to_bits(), v2.w.to_bits());
+    }
+
+    // -- Vector SLAB_SIZE constants ---------------------------------------
+
+    #[test]
+    fn vector_slab_sizes() {
+        assert_eq!(2, <Vec2<f32> as SlabItem>::SLAB_SIZE);
+        assert_eq!(3, <Vec3<f32> as SlabItem>::SLAB_SIZE);
+        assert_eq!(4, <Vec4<f32> as SlabItem>::SLAB_SIZE);
+
+        assert_eq!(2, <Vec2<i32> as SlabItem>::SLAB_SIZE);
+        assert_eq!(3, <Vec3<i32> as SlabItem>::SLAB_SIZE);
+        assert_eq!(4, <Vec4<i32> as SlabItem>::SLAB_SIZE);
+
+        assert_eq!(2, <Vec2<u32> as SlabItem>::SLAB_SIZE);
+        assert_eq!(3, <Vec3<u32> as SlabItem>::SLAB_SIZE);
+        assert_eq!(4, <Vec4<u32> as SlabItem>::SLAB_SIZE);
+
+        assert_eq!(2, <Vec2<bool> as SlabItem>::SLAB_SIZE);
+        assert_eq!(3, <Vec3<bool> as SlabItem>::SLAB_SIZE);
+        assert_eq!(4, <Vec4<bool> as SlabItem>::SLAB_SIZE);
+    }
+
+    // -- Matrix round-trip tests ------------------------------------------
+
+    /// Helper to compare two matrices by column.
+    fn assert_mat_eq<M: std::ops::Index<usize, Output = V>, V: PartialEq + std::fmt::Debug>(
+        a: &M,
+        b: &M,
+        cols: usize,
+    ) {
+        for c in 0..cols {
+            assert_eq!(a[c], b[c], "column {c} mismatch");
+        }
+    }
+
+    #[test]
+    fn mat2x2f_round_trip() {
+        let m = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 2);
+
+        let mut slab = [0u32; 8];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat2x2f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 2);
+    }
+
+    #[test]
+    fn mat2x3f_round_trip() {
+        let m = mat2x3f(vec3f(1.0, 2.0, 3.0), vec3f(4.0, 5.0, 6.0));
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 2);
+
+        let mut slab = [0u32; 12];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat2x3f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 2);
+    }
+
+    #[test]
+    fn mat2x4f_round_trip() {
+        let m = mat2x4f(vec4f(1.0, 2.0, 3.0, 4.0), vec4f(5.0, 6.0, 7.0, 8.0));
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 2);
+
+        let mut slab = [0u32; 16];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat2x4f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 2);
+    }
+
+    #[test]
+    fn mat3x2f_round_trip() {
+        let m = mat3x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0), vec2f(5.0, 6.0));
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 3);
+
+        let mut slab = [0u32; 12];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat3x2f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 3);
+    }
+
+    #[test]
+    fn mat3x3f_round_trip() {
+        let m = mat3x3f(
+            vec3f(1.0, 2.0, 3.0),
+            vec3f(4.0, 5.0, 6.0),
+            vec3f(7.0, 8.0, 9.0),
+        );
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 3);
+
+        let mut slab = [0u32; 18];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat3x3f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 3);
+    }
+
+    #[test]
+    fn mat3x4f_round_trip() {
+        let m = mat3x4f(
+            vec4f(1.0, 2.0, 3.0, 4.0),
+            vec4f(5.0, 6.0, 7.0, 8.0),
+            vec4f(9.0, 10.0, 11.0, 12.0),
+        );
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 3);
+
+        let mut slab = [0u32; 24];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat3x4f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 3);
+    }
+
+    #[test]
+    fn mat4x2f_round_trip() {
+        let m = mat4x2f(
+            vec2f(1.0, 2.0),
+            vec2f(3.0, 4.0),
+            vec2f(5.0, 6.0),
+            vec2f(7.0, 8.0),
+        );
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 4);
+
+        let mut slab = [0u32; 16];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat4x2f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 4);
+    }
+
+    #[test]
+    fn mat4x3f_round_trip() {
+        let m = mat4x3f(
+            vec3f(1.0, 2.0, 3.0),
+            vec3f(4.0, 5.0, 6.0),
+            vec3f(7.0, 8.0, 9.0),
+            vec3f(10.0, 11.0, 12.0),
+        );
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 4);
+
+        let mut slab = [0u32; 24];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat4x3f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 4);
+    }
+
+    #[test]
+    fn mat4x4f_round_trip() {
+        let m = mat4x4f(
+            vec4f(1.0, 2.0, 3.0, 4.0),
+            vec4f(5.0, 6.0, 7.0, 8.0),
+            vec4f(9.0, 10.0, 11.0, 12.0),
+            vec4f(13.0, 14.0, 15.0, 16.0),
+        );
+        let m2 = rt(&m);
+        assert_mat_eq(&m, &m2, 4);
+
+        let mut slab = [0u32; 32];
+        slab_write(&mut slab, 0, &m);
+        let m3: Mat4x4f = slab_read(&slab, 0);
+        assert_mat_eq(&m, &m3, 4);
+
+        // Non-zero offset.
+        slab_write(&mut slab, 16, &m);
+        let m4: Mat4x4f = slab_read(&slab, 16);
+        assert_mat_eq(&m, &m4, 4);
+    }
+
+    // -- Matrix SLAB_SIZE constants ---------------------------------------
+
+    #[test]
+    fn matrix_slab_sizes() {
+        assert_eq!(4, <Mat2x2f as SlabItem>::SLAB_SIZE);
+        assert_eq!(6, <Mat2x3f as SlabItem>::SLAB_SIZE);
+        assert_eq!(8, <Mat2x4f as SlabItem>::SLAB_SIZE);
+        assert_eq!(6, <Mat3x2f as SlabItem>::SLAB_SIZE);
+        assert_eq!(9, <Mat3x3f as SlabItem>::SLAB_SIZE);
+        assert_eq!(12, <Mat3x4f as SlabItem>::SLAB_SIZE);
+        assert_eq!(8, <Mat4x2f as SlabItem>::SLAB_SIZE);
+        assert_eq!(12, <Mat4x3f as SlabItem>::SLAB_SIZE);
+        assert_eq!(16, <Mat4x4f as SlabItem>::SLAB_SIZE);
+    }
+
+    // -- Matrix raw layout verification -----------------------------------
+
+    #[test]
+    fn mat2x2f_raw_layout() {
+        let m = mat2x2f(vec2f(1.0, 2.0), vec2f(3.0, 4.0));
+        let arr = SlabItem::to_array(&m);
+        // Column-major: col0(x,y), col1(x,y).
+        assert_eq!(1.0f32.to_bits(), arr[0]);
+        assert_eq!(2.0f32.to_bits(), arr[1]);
+        assert_eq!(3.0f32.to_bits(), arr[2]);
+        assert_eq!(4.0f32.to_bits(), arr[3]);
+    }
+
+    #[test]
+    fn mat4x4f_raw_layout() {
+        let m = mat4x4f(
+            vec4f(1.0, 2.0, 3.0, 4.0),
+            vec4f(5.0, 6.0, 7.0, 8.0),
+            vec4f(9.0, 10.0, 11.0, 12.0),
+            vec4f(13.0, 14.0, 15.0, 16.0),
+        );
+        let arr = SlabItem::to_array(&m);
+        // Column-major: col0(x,y,z,w), col1(x,y,z,w), ...
+        for i in 0..16 {
+            assert_eq!(((i + 1) as f32).to_bits(), arr[i], "mismatch at index {i}");
+        }
+    }
+}


### PR DESCRIPTION
These changes add SlabItem implementations for all 12 wgsl-rs vector types (Vec2/3/4 for f32, i32, u32, bool) and all 9 matrix types (Mat2x2f through Mat4x4f) behind an optional 'wgsl-rs' feature flag on the crabslab crate.

It also enables the `#[slab_module]` macro to recognize vector/matrix type names as struct fields and generate efficient component-wise serialization code (bitcast for f32, cast for i32, direct copy for u32, bool compare for bool) instead of treating them as opaque nested slab_item types.